### PR TITLE
Increases h1 contrast

### DIFF
--- a/docs/R-nav.css
+++ b/docs/R-nav.css
@@ -37,7 +37,7 @@ a:visited {
 
 h1 {
     background: white;
-    color: rgb(55%, 55%, 55%);
+    color: #6E6E6E;
     font-family: monospace;
     font-size: 1.4em; /* x-large; */
     text-align: center;


### PR DESCRIPTION
The contrast of the h1 element is [3.36](https://webaim.org/resources/contrastchecker/?fcolor=8C8C8C&bcolor=FFFFFF), which is too low for the size of the text. This increases the contrast to [5.09](https://webaim.org/resources/contrastchecker/?fcolor=8C8C8C&bcolor=FFFFFF).

This fixes some of the issues in #3